### PR TITLE
Enhance LibraryIQ API with new hold request endpoints

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/LibraryIQ/API.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/LibraryIQ/API.pm
@@ -131,7 +131,31 @@ sub items_full {
         WHERE  s.type IN ( 'issue', 'renew' )
                AND i.itemnumber = s.itemnumber
                AND Date(s.datetime) >= Concat( Date_format( Last_day( Now() - INTERVAL 1 month), '%Y-' ), '01-01') ) AS YTD,
-       i.issues + Ifnull(i.renewals, 0) AS lifetime
+       i.issues + Ifnull(i.renewals, 0) AS lifetime,
+        i.datelastseen AS last_inventoried_date,
+  i.`timestamp`   AS last_item_update,
+  COALESCE(
+  NULLIF(
+    GREATEST(
+      COALESCE(i.withdrawn_on, DATE '1900-01-01'),
+      COALESCE(i.itemlost_on, DATE '1900-01-01'),
+      COALESCE(i.damaged_on, DATE '1900-01-01')
+      -- add notforloan_on, restricted_on if your schema has them
+    ),
+    DATE '1900-01-01'
+  ),
+  (
+    SELECT MAX(al.`timestamp`)
+    FROM action_logs al
+    WHERE al.object = i.itemnumber
+      AND al.module IN ('CATALOGUING','CIRCULATION')
+      AND al.action IN ('MODIFY','SET_STATUS','UPDATE')
+      AND al.info REGEXP '(damaged|itemlost|withdrawn|notforloan|restricted)'
+  )
+) AS last_status_change_date
+
+       
+
 FROM   items i
        JOIN biblioitems bi
          ON i.biblionumber = bi.biblionumber
@@ -153,7 +177,7 @@ FROM   items i
         my $sth = $dbh->prepare($query);
         $sth->execute();
 
-        my @columns = ( 'item number', 'barcode', 'biblio number', 'isbn', 'collection code', 'item type', 'holding branch','home branch', 'cfull number', 'location', 'date accessioned', 'not for loan', 'damaged', 'item lost', 'withdrawn', 'to branch', 'found', 'date last borrowed', 'due date',  'ytd', 'lifetime circs' );
+        my @columns = ( 'item number', 'barcode', 'biblio number', 'isbn', 'collection code', 'item type', 'holding branch','home branch', 'cfull number', 'location', 'date accessioned', 'not for loan', 'damaged', 'item lost', 'withdrawn', 'to branch', 'found', 'date last borrowed', 'due date',  'ytd', 'lifetime circs', 'last inventoried date', 'last item update', 'last status change date' );
         my $tsv = join("\t", @columns) . "\n";
 
         while (my @row = $sth->fetchrow_array) {
@@ -198,7 +222,31 @@ sub items_delta {
         WHERE  s.type IN ( 'issue', 'renew' )
                AND i.itemnumber = s.itemnumber
                AND Date(s.datetime) >= Concat( Date_format( Last_day( Now() - INTERVAL 1 month), '%Y-' ), '01-01') ) AS YTD,
-       i.issues + Ifnull(i.renewals, 0) AS lifetime
+       i.issues + Ifnull(i.renewals, 0) AS lifetime,
+        i.datelastseen AS last_inventoried_date,
+  i.`timestamp`   AS last_item_update,
+  COALESCE(
+  NULLIF(
+    GREATEST(
+      COALESCE(i.withdrawn_on, DATE '1900-01-01'),
+      COALESCE(i.itemlost_on, DATE '1900-01-01'),
+      COALESCE(i.damaged_on, DATE '1900-01-01')
+      -- add notforloan_on, restricted_on if your schema has them
+    ),
+    DATE '1900-01-01'
+  ),
+  (
+    SELECT MAX(al.`timestamp`)
+    FROM action_logs al
+    WHERE al.object = i.itemnumber
+      AND al.module IN ('CATALOGUING','CIRCULATION')
+      AND al.action IN ('MODIFY','SET_STATUS','UPDATE')
+      AND al.info REGEXP '(damaged|itemlost|withdrawn|notforloan|restricted)'
+  )
+) AS last_status_change_date
+
+       
+
 FROM   items i
        JOIN biblioitems bi
          ON i.biblionumber = bi.biblionumber
@@ -221,7 +269,7 @@ WHERE  i.timestamp > Now() - INTERVAL 3 day
         my $sth = $dbh->prepare($query);
         $sth->execute();
 
-        my @columns = ( 'item number', 'barcode', 'biblio number', 'isbn', 'collection code', 'item type', 'holding branch','home branch', 'cfull number', 'location', 'date accessioned', 'not for loan', 'damaged', 'item lost', 'withdrawn', 'to branch', 'found', 'date last borrowed', 'due date',  'ytd', 'lifetime circs' );
+        my @columns = ( 'item number', 'barcode', 'biblio number', 'isbn', 'collection code', 'item type', 'holding branch','home branch', 'cfull number', 'location', 'date accessioned', 'not for loan', 'damaged', 'item lost', 'withdrawn', 'to branch', 'found', 'date last borrowed', 'due date',  'ytd', 'lifetime circs', 'last inventoried date', 'last item update', 'last status change date' );
         my $tsv = join("\t", @columns) . "\n";
 
         while (my @row = $sth->fetchrow_array) {
@@ -484,6 +532,240 @@ WHERE  type = 'localuse'
         $sth->execute();
 
         my @columns = ( 'item number', 'barcode', 'biblio number',  'datetime', 'branch', 'patron id' );
+        my $tsv = join("\t", @columns) . "\n";
+
+        while (my @row = $sth->fetchrow_array) {
+            $tsv .= join("\t", @row) . "\n";
+        }
+
+        return $c->render( status => 200, format => "text", text => $tsv );
+    } catch {
+        warn "LibraryIQ Plugin ERROR: $_";
+        $c->unhandled_exception($_);
+    };
+}
+
+sub requested_holds_full {
+    warn "Koha::Plugin::Com::ByWaterSolutions::LibraryIQ::API::requested_holds_full";
+    my $c = shift->openapi->valid_input or return;
+
+    return try {
+
+        my $query = q{
+SELECT 
+        r.biblionumber AS BibliographicRecordID,
+        r.reserve_id AS HoldRequestID,
+        r.branchcode AS pickupLocation,
+        r.reservedate AS RequestedDate,
+        Now() AS ReportDate
+    FROM reserves r
+    WHERE r.biblionumber IS NOT NULL 
+        AND r.branchcode IS NOT NULL 
+        AND r.reservedate >= Now() - INTERVAL 2 year
+        AND r.reservedate < Now()
+
+    UNION ALL
+
+    SELECT 
+        res.biblionumber AS BibliographicRecordID,
+        res.reserve_id AS HoldRequestID,
+        res.branchcode AS pickupLocation,
+        res.reservedate AS RequestedDate,
+        Now() AS ReportDate
+    FROM old_reserves res    
+    WHERE res.biblionumber IS NOT NULL 
+        AND res.branchcode IS NOT NULL 
+        AND res.reservedate >= Now() - INTERVAL 2 year
+        AND res.reservedate < Now()
+        };
+
+        my $dbh = C4::Context->dbh;
+        my $sth = $dbh->prepare($query);
+        $sth->execute();
+
+        my @columns = ( 'BibliographicRecordID', 'HoldRequestID', 'pickupLocation', 'RequestedDate', 'ReportDate' );
+        my $tsv = join("\t", @columns) . "\n";
+
+        while (my @row = $sth->fetchrow_array) {
+            $tsv .= join("\t", @row) . "\n";
+        }
+
+        return $c->render( status => 200, format => "text", text => $tsv );
+    } catch {
+        warn "LibraryIQ Plugin ERROR: $_";
+        $c->unhandled_exception($_);
+    };
+}
+
+sub requested_holds_delta {
+    warn "Koha::Plugin::Com::ByWaterSolutions::LibraryIQ::API::requested_holds_delta";
+    my $c = shift->openapi->valid_input or return;
+
+    return try {
+
+        my $query = q{
+SELECT 
+        r.biblionumber AS BibliographicRecordID,
+        r.reserve_id AS HoldRequestID,
+        r.branchcode AS pickupLocation,
+        r.reservedate AS RequestedDate,
+        Now() AS ReportDate
+    FROM reserves r
+    WHERE r.biblionumber IS NOT NULL 
+        AND r.branchcode IS NOT NULL 
+        AND r.reservedate >= Now() - INTERVAL 1 week
+        AND r.reservedate < Now()
+
+    UNION ALL
+
+    SELECT 
+        res.biblionumber AS BibliographicRecordID,
+        res.reserve_id AS HoldRequestID,
+        res.branchcode AS pickupLocation,
+        res.reservedate AS RequestedDate,
+        Now() AS ReportDate
+    FROM old_reserves res    
+    WHERE res.biblionumber IS NOT NULL 
+        AND res.branchcode IS NOT NULL 
+        AND res.reservedate >= Now() - INTERVAL 1 week
+        AND res.reservedate < Now()
+        };
+
+        my $dbh = C4::Context->dbh;
+        my $sth = $dbh->prepare($query);
+        $sth->execute();
+
+        my @columns = ( 'BibliographicRecordID', 'HoldRequestID', 'pickupLocation', 'RequestedDate', 'ReportDate' );
+        my $tsv = join("\t", @columns) . "\n";
+
+        while (my @row = $sth->fetchrow_array) {
+            $tsv .= join("\t", @row) . "\n";
+        }
+
+        return $c->render( status => 200, format => "text", text => $tsv );
+    } catch {
+        warn "LibraryIQ Plugin ERROR: $_";
+        $c->unhandled_exception($_);
+    };
+}
+
+sub fulfilled_holds_full {
+    warn "Koha::Plugin::Com::ByWaterSolutions::LibraryIQ::API::fulfilled_holds_full";
+    my $c = shift->openapi->valid_input or return;
+
+    return try {
+
+        my $query = q{
+SELECT 
+        res.biblionumber AS BibliographicRecordID,
+        res.reserve_id AS HoldRequestID,
+        res.branchcode as pickupLocation,
+        res.waitingdate AS FulfilledDate,
+        Now() AS ReportDate
+    FROM old_reserves res
+        LEFT JOIN borrowers b ON res.borrowernumber = b.borrowernumber
+        LEFT JOIN deletedborrowers db ON res.borrowernumber = db.borrowernumber
+        LEFT JOIN biblio bib ON res.biblionumber = bib.biblionumber
+        LEFT JOIN deletedbiblio dbib ON res.biblionumber = dbib.biblionumber
+        LEFT JOIN items i ON res.itemnumber = i.itemnumber
+        LEFT JOIN deleteditems di ON res.itemnumber = di.itemnumber
+        LEFT JOIN branches br ON res.branchcode = br.branchcode
+    WHERE res.biblionumber IS NOT NULL 
+        AND res.branchcode IS NOT NULL 
+        AND res.found = 'F'  
+        AND res.waitingdate >= Now() - INTERVAL 2 year
+        AND res.waitingdate < Now()
+        };
+
+        my $dbh = C4::Context->dbh;
+        my $sth = $dbh->prepare($query);
+        $sth->execute();
+
+        my @columns = ( 'BibliographicRecordID', 'HoldRequestID', 'pickupLocation', 'FulfilledDate', 'ReportDate' );
+        my $tsv = join("\t", @columns) . "\n";
+
+        while (my @row = $sth->fetchrow_array) {
+            $tsv .= join("\t", @row) . "\n";
+        }
+
+        return $c->render( status => 200, format => "text", text => $tsv );
+    } catch {
+        warn "LibraryIQ Plugin ERROR: $_";
+        $c->unhandled_exception($_);
+    };
+}
+
+sub fulfilled_holds_delta {
+    warn "Koha::Plugin::Com::ByWaterSolutions::LibraryIQ::API::fulfilled_holds_delta";
+    my $c = shift->openapi->valid_input or return;
+
+    return try {
+
+        my $query = q{
+SELECT 
+        res.biblionumber AS BibliographicRecordID,
+        res.reserve_id AS HoldRequestID,
+        res.branchcode as pickupLocation,
+        res.waitingdate AS FulfilledDate,
+        Now() AS ReportDate
+    FROM old_reserves res
+        LEFT JOIN borrowers b ON res.borrowernumber = b.borrowernumber
+        LEFT JOIN deletedborrowers db ON res.borrowernumber = db.borrowernumber
+        LEFT JOIN biblio bib ON res.biblionumber = bib.biblionumber
+        LEFT JOIN deletedbiblio dbib ON res.biblionumber = dbib.biblionumber
+        LEFT JOIN items i ON res.itemnumber = i.itemnumber
+        LEFT JOIN deleteditems di ON res.itemnumber = di.itemnumber
+        LEFT JOIN branches br ON res.branchcode = br.branchcode
+    WHERE res.biblionumber IS NOT NULL 
+        AND res.branchcode IS NOT NULL 
+        AND res.found = 'F'  
+        AND res.waitingdate >= Now() - INTERVAL 1 week
+        AND res.waitingdate < Now()
+        };
+
+        my $dbh = C4::Context->dbh;
+        my $sth = $dbh->prepare($query);
+        $sth->execute();
+
+        my @columns = ( 'BibliographicRecordID', 'HoldRequestID', 'pickupLocation', 'FulfilledDate', 'ReportDate' );
+        my $tsv = join("\t", @columns) . "\n";
+
+        while (my @row = $sth->fetchrow_array) {
+            $tsv .= join("\t", @row) . "\n";
+        }
+
+        return $c->render( status => 200, format => "text", text => $tsv );
+    } catch {
+        warn "LibraryIQ Plugin ERROR: $_";
+        $c->unhandled_exception($_);
+    };
+}
+
+sub unfilled_holds_full {
+    warn "Koha::Plugin::Com::ByWaterSolutions::LibraryIQ::API::unfilled_holds_full";
+    my $c = shift->openapi->valid_input or return;
+
+    return try {
+
+        my $query = q{
+SELECT 
+        r.biblionumber as BibliographicRecordID,
+        r.reserve_id AS HoldRequestID,
+        r.reservedate AS RequestedDate,
+        r.branchcode AS RequestedPickupLocation
+    FROM reserves r
+        LEFT JOIN borrowers b ON r.borrowernumber = b.borrowernumber
+        LEFT JOIN biblio bib ON r.biblionumber = bib.biblionumber
+    WHERE  (r.found IS NULL OR r.found = 'T')
+        AND r.suspend = 0
+    ORDER BY r.priority ASC
+        };
+
+        my $dbh = C4::Context->dbh;
+        my $sth = $dbh->prepare($query);
+        $sth->execute();
+
+        my @columns = ( 'BibliographicRecordID', 'HoldRequestID', 'RequestedDate', 'RequestedPickupLocation' );
         my $tsv = join("\t", @columns) . "\n";
 
         while (my @row = $sth->fetchrow_array) {

--- a/Koha/Plugin/Com/ByWaterSolutions/LibraryIQ/openapi.json
+++ b/Koha/Plugin/Com/ByWaterSolutions/LibraryIQ/openapi.json
@@ -372,5 +372,175 @@
                 }
             }
         }
+    },
+    "/requestedHolds/full": {
+        "get": {
+            "x-mojo-to": "Com::ByWaterSolutions::LibraryIQ::API#requested_holds_full",
+            "operationId": "libraryIqGetRequestedHoldsFull",
+            "tags": [
+                "requested_holds"
+            ],
+            "produces": [
+                "application/tsv"
+            ],
+            "responses": {
+                "200": {
+                    "description": "Data"
+                },
+                "404": {
+                    "description": "An error occured",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {
+                                "description": "An explanation for the error",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "x-koha-authorization": {
+                "permissions": {
+                    "catalogue": "1"
+                }
+            }
+        }
+    },
+    "/requestedHolds/delta": {
+        "get": {
+            "x-mojo-to": "Com::ByWaterSolutions::LibraryIQ::API#requested_holds_delta",
+            "operationId": "libraryIqGetRequestedHoldsDelta",
+            "tags": [
+                "requested_holds"
+            ],
+            "produces": [
+                "application/tsv"
+            ],
+            "responses": {
+                "200": {
+                    "description": "Data"
+                },
+                "404": {
+                    "description": "An error occured",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {
+                                "description": "An explanation for the error",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "x-koha-authorization": {
+                "permissions": {
+                    "catalogue": "1"
+                }
+            }
+        }
+    },
+    "/fulfilledHolds/full": {
+        "get": {
+            "x-mojo-to": "Com::ByWaterSolutions::LibraryIQ::API#fulfilled_holds_full",
+            "operationId": "libraryIqGetFulfilledHoldsFull",
+            "tags": [
+                "fulfilled_holds"
+            ],
+            "produces": [
+                "application/tsv"
+            ],
+            "responses": {
+                "200": {
+                    "description": "Data"
+                },
+                "404": {
+                    "description": "An error occured",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {
+                                "description": "An explanation for the error",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "x-koha-authorization": {
+                "permissions": {
+                    "catalogue": "1"
+                }
+            }
+        }
+    },
+    "/fulfilledHolds/delta": {
+        "get": {
+            "x-mojo-to": "Com::ByWaterSolutions::LibraryIQ::API#fulfilled_holds_delta",
+            "operationId": "libraryIqGetFulfilledHoldsDelta",
+            "tags": [
+                "fulfilled_holds"
+            ],
+            "produces": [
+                "application/tsv"
+            ],
+            "responses": {
+                "200": {
+                    "description": "Data"
+                },
+                "404": {
+                    "description": "An error occured",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {
+                                "description": "An explanation for the error",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "x-koha-authorization": {
+                "permissions": {
+                    "catalogue": "1"
+                }
+            }
+        }
+    },
+    "/unfilledHolds/full": {
+        "get": {
+            "x-mojo-to": "Com::ByWaterSolutions::LibraryIQ::API#unfilled_holds_full",
+            "operationId": "libraryIqGetUnfilledHoldsFull",
+            "tags": [
+                "unfilled_holds"
+            ],
+            "produces": [
+                "application/tsv"
+            ],
+            "responses": {
+                "200": {
+                    "description": "Data"
+                },
+                "404": {
+                    "description": "An error occured",
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "error": {
+                                "description": "An explanation for the error",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "x-koha-authorization": {
+                "permissions": {
+                    "catalogue": "1"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- Added `requested_holds_full` and `requested_holds_delta` methods to retrieve hold requests data.
- Introduced `fulfilled_holds_full` and `fulfilled_holds_delta` methods for fulfilled holds data.
- Implemented `unfilled_holds_full` method to fetch unfilled hold requests.
- Updated OpenAPI specification to include new endpoints with appropriate response formats and permissions.

These enhancements improve the API's functionality and provide better access to hold request data.

Updates provided for discussion in our follow on meeting.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance LibraryIQ API by adding new hold request endpoints (requested_holds_full, requested_holds_delta, fulfilled_holds_full, fulfilled_holds_delta, unfilled_holds_full) and extend item-related reports to include last inventoried date, last item update, and last status change date.

### Why are these changes being made?

Provide richer hold-request and item-status data for inventory and circulation workflows, improving visibility into current and recent changes without altering core data flows. If applicable, these endpoints align the API with the expanded reporting fields added to item queries.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->